### PR TITLE
Fixed Username Error

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,7 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					showError(usernameInput, username_notify, `[[error:username-taken. Maybe try ${username} suffix]]`);
 				}
 
 				callback();


### PR DESCRIPTION
Whenever someone tries to use the already in use username, they will get a notification that it is already in use and the error suggests new username.