### PR TITLE
fixed-username-taken-issue

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try %1",
     "email-taken": "Email address is already taken.",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken. Maybe try %1",
+    "username-taken": "Username taken",
     "email-taken": "Email address is already taken.",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -126,7 +126,7 @@ define('forum/register', [
 		} else if (username.length > ajaxify.data.maximumUsernameLength) {
 			showError(usernameInput, username_notify, '[[error:username-too-long]]');
 		} else if (!utils.isUserNameValid(username) || !userslug) {
-			showError(usernameInput, username_notify, 'Username taken. Maybe try &(currentUsername)suffix');
+			showError(usernameInput, username_notify, '[[error:username-taken]]');
 		} else {
 			Promise.allSettled([
 				api.head(`/users/bySlug/${userslug}`, {}),
@@ -135,7 +135,7 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					showError(usernameInput, username_notify, `[[error:username-taken]] Maybe try ${usernameInput.val()}suffix`);
 				}
 
 				callback();

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -126,7 +126,7 @@ define('forum/register', [
 		} else if (username.length > ajaxify.data.maximumUsernameLength) {
 			showError(usernameInput, username_notify, '[[error:username-too-long]]');
 		} else if (!utils.isUserNameValid(username) || !userslug) {
-			showError(usernameInput, username_notify, '[[error:invalid-username]]');
+			showError(usernameInput, username_notify, 'Username taken. Maybe try &(currentUsername)suffix');
 		} else {
 			Promise.allSettled([
 				api.head(`/users/bySlug/${userslug}`, {}),


### PR DESCRIPTION
I made made one change to the file register.js to suggest an alternative username when the original is taken. In the file, I updated line 129 to "showError(usernameInput, username_notify, `[[error:username-taken]] Maybe try ${usernameInput.val()}suffix`);". 

Fixed issue of username taken.

Resolves #1